### PR TITLE
Implement MoCo-style momentum queue for MulSupCon training

### DIFF
--- a/src/config/config_nlp.json
+++ b/src/config/config_nlp.json
@@ -14,5 +14,6 @@
     "beta": [0.1],
     "alpha": [0],
     "loss" : ["proto", "msc", "base", "mscrg", "mscwrg", "mulsupcon"],
-    "task_type": "NLP"                                                                                            
+    "task_type": "NLP",
+    "queue_size": [512]
 }


### PR DESCRIPTION
## Summary
- add a momentum-updated key encoder and feature queue to the trainer to reuse past batches during MulSupCon training
- extend the MulSupCon and MSC losses to consume key/queue features and safely handle empty interaction cases
- allow the momentum queue size to be configured from the training config

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c8adfcadec8329932c8ca5a3942124